### PR TITLE
Add "clean" target to top-level Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,7 @@ transfers-*
 test/data/*
 TestReport-case.xml
 *.pyc
+tests/*.log
+tests/agave_mock_server/*.egg-info
 
 .TODO

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: authors cli run-tests
+.PHONY: authors cli run-tests clean
 
 authors:
 	git log --format='%aN <%aE>' | sort -u --ignore-case | grep -v 'users.noreply.github.com' > AUTHORS.txt && \
@@ -11,3 +11,6 @@ cli:
 
 run-tests:
 	make -C tests/ run-tests
+
+clean:
+	make -C tests/ clean


### PR DESCRIPTION
The clean target will remove all artifacts created after running tests
("run-tests" Makefile target).

Signed-off-by: Jorge Alarcon Ochoa <alarcj137@gmail.com>