### PR TITLE
Adding postits-list test

### DIFF
--- a/tests/agave_mock_server/agave_mock_server/api.py
+++ b/tests/agave_mock_server/agave_mock_server/api.py
@@ -2,6 +2,7 @@ from flask import Flask
 from flask_restful import Api
 from .apps_endpoints import AgaveApps
 from .clients_endpoints import AgaveClients
+from .postits_endpoints import AgavePostits
 
 app = Flask(__name__)
 app.config["JSONIFY_PRETTYPRINT_REGULAR"] = True
@@ -10,6 +11,7 @@ api = Api(app)
 api.add_resource(AgaveApps, "/apps/v2")
 api.add_resource(AgaveClients, "/clients/v2/",
                  "/clients/v2/<string:client_name>")
+api.add_resource(AgavePostits, "/postits/v2/")
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", ssl_context="adhoc")

--- a/tests/agave_mock_server/agave_mock_server/postits_endpoints.py
+++ b/tests/agave_mock_server/agave_mock_server/postits_endpoints.py
@@ -1,0 +1,31 @@
+"""
+    postits_endpoints.py
+
+CLI integration tests for "postits-*" cli commands.
+"""
+import json
+from flask import jsonify, request
+from flask_restful import Resource
+
+
+# Sample response for "postits-list" cli command.
+response = "/agave-cli/tests/agave_mock_server/agave_mock_server/responses/postits-list.response"
+with open(response, 'r') as infile:
+    postits_list_response = json.load(infile)
+
+
+
+class AgavePostits(Resource):
+    """ Test postits-* cli commands
+    """
+
+    def get(self):
+        """ Test postits-list utility
+
+        This test emulates the Agave API endpoint "/postits/v2/" for GET
+        requests. To test it:
+
+        curl -sk -H "Authorization: Bearer xxx" 'https://localhost:5000/postits/v2/?pretty=true'
+        """
+        pretty_print = request.args.get("pretty", "")
+        return jsonify(postits_list_response)

--- a/tests/agave_mock_server/agave_mock_server/responses/postits-list.response
+++ b/tests/agave_mock_server/agave_mock_server/responses/postits-list.response
@@ -1,0 +1,29 @@
+{
+  "status": "success",
+  "message": "",
+  "result": [
+    {
+      "created": "2018-08-10T12:31:38-05:00",
+      "expires": "2018-08-10T13:31:38-05:00",
+      "internalUsername": "",
+      "url": "https://api.sd2e.org/files/v2/media/system/data-sd2e-community/sample/requirements.txt",
+      "method": "GET",
+      "noauth": false,
+      "remainingUses": 5,
+      "postit": "a83dc9c6ff7e6bca4173b81d7ef632f7",
+      "creator": "wallen",
+      "_links": {
+        "self": {
+          "href": "https://api.sd2e.org/postits/v2/a83dc9c6ff7e6bca4173b81d7ef632f7"
+        },
+        "profile": {
+          "href": "https://api.sd2e.org/profiles/v2/wallen"
+        },
+        "file": {
+          "href": "https://api.sd2e.org/files/v2/media/system/data-sd2e-community/sample/requirements.txt"
+        }
+      }
+    }
+  ],
+  "version": "2.2.22-r7deb380"
+}

--- a/tests/integration_tests/test_postits-list.bats
+++ b/tests/integration_tests/test_postits-list.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+@test "postits-list lists all active postits" {
+/usr/bin/expect <(cat <<EOF
+    spawn postits-list -V
+    expect "Access token :"
+    send "xxxx\n"
+    interact
+EOF
+) | grep "success"
+    [ "$?" -eq 0 ]
+}


### PR DESCRIPTION
Added a simple postits-list bats test for agave cli. Currently tests against mock server; only tests postits-list -V flag for functionality. Will likely want to test more flags in the future.

