### PR TITLE
Output tests results to file and fix run-tests target

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,6 +43,7 @@ tests-setup:
 	./hack/wait-for-it.sh localhost:5000 -- echo "Server is up" || exit 1
 
 clean:
+	rm -rf tests_results.tap
 	rm -rf agave_mock_server.log
 	rm -rf agave_mock_server/agave_mock_server.egg-info
 	rm -rf agave_mock_server/__pycache__/

--- a/tests/hack/run-integration-tests.run
+++ b/tests/hack/run-integration-tests.run
@@ -2,8 +2,8 @@
 set -e
 
 
-/agave-cli/tests/hack/setup_agavedb.sh && \
+/agave-cli/tests/hack/setup_agavedb.py && \
     pip install -e /agave-cli/tests/agave_mock_server && \
     /agave-cli/tests/hack/serve_agave_mock_server.sh && \
     /agave-cli/tests/hack/wait-for-it.sh localhost:5000 -- echo "Server is up" && \
-    bats /agave-cli/tests/integration_tests --tap
+    bats /agave-cli/tests/integration_tests --tap 2>&1 | tee /agave-cli/tests/tests_results.tap


### PR DESCRIPTION
Resolves #5 and fixes the run-tests make target
(run-integration-tests.run depended on an old version of
 setup_agavedb.py).

Signed-off-by: Jorge Alarcon Ochoa <alarcj137@gmail.com>