### PR TITLE
Fix apps-init

### DIFF
--- a/bin/apps-deploy-common.sh
+++ b/bin/apps-deploy-common.sh
@@ -9,9 +9,11 @@ if [[ -z "$DIR" ]]; then
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 fi
 
+# TODO: getting rid of this dependency checking. If an external tool is to be
+# used the the command that uses it should report directly to the user. 
 # Command build on apps-deploy leverages multiple external dependencies:
 # Return an error if essentials are missing!
-check_dependencies
+#check_dependencies
 
 cliauthopt=
 if [ ! -z "$auth_token" ]; then

--- a/bin/apps-init
+++ b/bin/apps-init
@@ -9,9 +9,9 @@ source "$DIR/template-common.sh"
 
 # check_dependencies is permissive, only failing if python and jq are
 #   unavailable, but apps-init & apps-deploy need to be more strict
-if ((! hasgit)) || (( ! hasdocker )); then
-  err "Both Git and Docker must be installed to use $(basename $0)"
-fi
+#if ((! hasgit)) || (( ! hasdocker )); then
+#  err "Both Git and Docker must be installed to use $(basename $0)"
+#fi
 
 function usage() {
 
@@ -384,7 +384,9 @@ function preflight_pull() {
 function main() {
 
   OWD=$(pwd)
-  preflight_auth_integrations
+  # TODO: getting rid of this dependency checking. If an external tool is to be
+  # used the the command that uses it should report directly to the user. 
+  #preflight_auth_integrations
 
   # Extends the Bash environment with per-tenant configs
   local globalconfig=$(get_tenant_config)


### PR DESCRIPTION
apps-init will fail due to the fact it uses a "lets check for all
dependencies" type behaviour. This commit gets rid of this type of dependency
checking. If an external tool is to be used the the command then the command
that uses it should report directly to the user.

Signed-off-by: Jorge Alarcon Ochoa <alarcj137@gmail.com>