### PR TITLE
Fix documentation path exports and other little things

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ v0.8+.
 To install [TACC/agavepy](https://github.com/TACC/agavepy) from source you'll
 need to clone the repo and and install it as such:
 ```shell
-git clone https://github.com/TACC/agavepy
+$ git clone https://github.com/TACC/agavepy
 
-make install
+$ cd agavepy
+
+$ make install
 ```
 
 Once you have these requirements installed, you'll need to clone this
@@ -61,11 +63,11 @@ $ export PATH=$PATH:$PWD/bin
 
 To persist the new `$PATH` between logins, run
 ```shell
-echo "export PATH=$PATH:$PWD/bin" >> ~/.bashrc
+$ echo "export PATH=$PATH:$PWD/bin" >> ~/.bashrc
 ```
 or
 ```shell
-echo "export PATH=$PATH:$PWD/bin" >> ~/.bash_profile
+$ echo "export PATH=$PATH:$PWD/bin" >> ~/.bash_profile
 ```
 
 
@@ -127,7 +129,7 @@ The Agave CLI is broken down into the following groups of scripts
 	- tenants*        query and initialize the CLI for your tenant
 	- uuid*           lookup and expand one or more Agave UUID
 
-All commands follow a common syntax and share many of the same flags `-h` for help, `-d` for debug mode, `-v` for verbose output, `-V` for very verbose (prints curl command and full service response), and `-i` for interactive mode. Additionaly, individual commands will have their own options specific to their functionality. The general syntax all commands follow is:
+All commands follow a common syntax and share many of the same flags `-h` for help, `-d` for debug mode, `-v` for verbose output, `-V` for very verbose (prints curl command and full service response), and `-i` for interactive mode. Additionally, individual commands will have their own options specific to their functionality. The general syntax all commands follow is:
 
 	<command> [-hdv]
 	<command> [-hdv] [target]

--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ Once you have these requirements installed, you'll need to clone this
 repository and add it to your `$PATH`.
 
 ```shell
-$ git https://github.com/TACC-Cloud/agave-cli
+$ git clone https://github.com/TACC-Cloud/agave-cli
 
 $ cd agave-cli
 
-$ export PATH=$PATH:$PWD/agave-cli/bin
+$ export PATH=$PATH:$PWD/bin
 ```
 
 To persist the new `$PATH` between logins, run
 ```shell
-echo "export PATH=$PATH:$PWD/agave-cli/bin" >> ~/.bashrc
+echo "export PATH=$PATH:$PWD/bin" >> ~/.bashrc
 ```
 or
 ```shell
-echo "export PATH=$PATH:$PWD/agave-cli/bin" >> ~/.bash_profile
+echo "export PATH=$PATH:$PWD/bin" >> ~/.bash_profile
 ```
 
 
@@ -73,12 +73,12 @@ echo "export PATH=$PATH:$PWD/agave-cli/bin" >> ~/.bash_profile
 
 To get more details 
 [see the documentation for the latest changes](docs/docsite).
-For more oficial documentation see
+For more official documentation see
 [Agave](https://tacc-cloud.readthedocs.io/projects/agave/en/latest/).
 
 The first time you use the CLI, you will need to create a session.
 You will need to create credentials to interact with a tenant.
-The credentials will, by default, be store in `~/.agave/`.
+The credentials will, by default, be stored in `~/.agave/`.
 
 ```
 $ auth-session-init 

--- a/docs/docsite/authentication/auth.rst
+++ b/docs/docsite/authentication/auth.rst
@@ -31,7 +31,7 @@ initiate a session as follows:
     Getting oauth bearer tokens...
     API password:
 
-You shoould now be ready to interact with the rest of TACC's services.
+You should now be ready to interact with the rest of TACC's services.
 ``auth-session-init`` will save your session configuration by default in
 ``~/.agave``, unless you specify another location using the ``-c, --cachedir``
 flag.


### PR DESCRIPTION
## Description                                                                  
Modified the README.md to make exporting paths work after `cd`ing into the agave-cli directory. Fixed git command and other small things like formatting in shell blocks and spelling. 
Fixed a spelling error in auth.rst                                     

https://github.com/TACC-Cloud/agave-cli/issues/94
- [x] I have raised an issue to propose this change (required)
                                                                                
## Types of changes                                                             
- [x] Bug fix (non-breaking change which fixes an issue)                        
- [ ] New feature (non-breaking change which adds functionality)                
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
                                                                                
## Checklist:                                                                   
- [ ] My code follows the code style of this project.                           
- [ ] My change requires a change to the documentation.                         
- [x] I have updated the documentation accordingly.                             
- [ ] I have signed-off my commits with `git commit -s`                         
- [ ] I have added tests to cover my changes.                                   
- [ ] All new and existing tests passed.
