### PR TITLE
Implement Python3

### DIFF
--- a/Dockerfile.public
+++ b/Dockerfile.public
@@ -8,14 +8,22 @@ LABEL org.label-schema.version = "3.0.1"
 LABEL org.label-schema.organization=tacc.cloud
 LABEL cloud.tacc.project="Tapis API CLI"
 
-ARG AGAVEPY_BRANCH=v0.8.0
-ARG PYTHON_PIP_VERSION=9.0.3
+ARG AGAVEPY_BRANCH=master
+ARG PYTHON_PIP_VERSION=19.1.1
 
-#### This is a temporary fix for an issue with OverlayFS on TACC systems ###
-RUN mkdir -p /work && chown root:root /work
-RUN mkdir -p /gpfs && chown root:root /gpfs
-RUN mkdir -p /data && chown root:root /data
-RUN mkdir -p /scratch && chown root:root /scratch
+# Force locale to UTF-8
+RUN apt-get update && \
+    apt-get install -y locales locales-all && \
+    apt-get clean
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# #### This is a temporary fix for an issue with OverlayFS on TACC systems ###
+# RUN mkdir -p /work && chown root:root /work
+# RUN mkdir -p /gpfs && chown root:root /gpfs
+# RUN mkdir -p /data && chown root:root /data
+# RUN mkdir -p /scratch && chown root:root /scratch
 
 # In-container volume mounts
 # (For containers launched using TACC.cloud SSO identity)

--- a/Dockerfile.public.py2
+++ b/Dockerfile.public.py2
@@ -1,0 +1,82 @@
+FROM ubuntu:cosmic
+
+LABEL org.label-schema.vendor = "Texas Advanced Computing Center"
+LABEL org.label-schema.name = "TACC Tapis API CLI"
+LABEL org.label-schema.vcs-url = "https://github.com/TACC-Cloud/home"
+LABEL org.label-schema.vcs-ref = "master"
+LABEL org.label-schema.version = "3.0.1"
+LABEL org.label-schema.organization=tacc.cloud
+LABEL cloud.tacc.project="Tapis API CLI"
+
+ARG AGAVEPY_BRANCH=master
+ARG PYTHON_PIP_VERSION=19.1.1
+
+# Force locale to UTF-8
+RUN apt-get update && \
+    apt-get install -y locales locales-all && \
+    apt-get clean
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# #### This is a temporary fix for an issue with OverlayFS on TACC systems ###
+# RUN mkdir -p /work && chown root:root /work
+# RUN mkdir -p /gpfs && chown root:root /gpfs
+# RUN mkdir -p /data && chown root:root /data
+# RUN mkdir -p /scratch && chown root:root /scratch
+
+# In-container volume mounts
+# (For containers launched using TACC.cloud SSO identity)
+ARG CORRAL=/corral
+ARG STOCKYARD=/work/projects
+
+# Basics
+RUN apt-get -y update && \
+    apt-get -y install --no-install-recommends \
+    apt-utils bash curl dialog git vim rsync && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# jq for parsing JSON
+RUN curl -L -sk -o /usr/local/bin/jq "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64" \
+    && chmod a+x /usr/local/bin/jq
+
+RUN apt-get -y update && \
+    apt-get -y install --no-install-recommends \
+    python \
+    python-pip \
+    python-setuptools && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Make python3 the default user python
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python2 10
+RUN pip install --upgrade pip==${PYTHON_PIP_VERSION}
+RUN pip install --upgrade virtualenv==16.0.0
+
+# Make pip behave
+RUN curl -skL -o /etc/pip.conf \
+    https://raw.githubusercontent.com/SD2E/base-images/master/languages/python3/files/pip.conf
+
+# AgavePy
+WORKDIR /tmp
+RUN git clone https://github.com/TACC/agavepy \
+    && cd agavepy \
+    && git fetch --all && \
+    git checkout ${AGAVEPY_BRANCH} && \
+    python setup.py install --quiet
+
+RUN mkdir -p /home
+WORKDIR /home
+
+COPY bin /home/bin
+COPY completion/agave-cli /etc/bash_completion.d/agave-cli
+COPY etc /home/etc
+ENV PATH $PATH:/home/bin
+ENV HOME /home
+ENV AGAVE_CACHE_DIR=/home/.agave
+
+# Set command prompt
+RUN echo 'source /home/etc/.dockerprompt' >> /home/.bashrc
+
+CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,11 @@ clean:
 public-image:
 	docker build $(DOCKER_BUILD_ARGS) -f Dockerfile.public -t tacc/tapis-cli:latest .
 
+public-image-py2:
+	docker build $(DOCKER_BUILD_ARGS) -f Dockerfile.public.py2 -t tacc/tapis-cli:python2 .
+
 interactive: public-image
 	docker run --rm -it $(DOCKER_MOUNT) $(DOCKER_MOUNT_AUTHCACHE) $(PUBLIC_DOCKER_IMAGE) bash
+
+interactive-py2: public-image
+	docker run --rm -it $(DOCKER_MOUNT) $(DOCKER_MOUNT_AUTHCACHE) tacc/tapis-cli:python2 bash

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,12 @@ PY_SRC != ./hack/find_python_files.sh
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 DOCKER_IMAGE := agave-cli$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
+PUBLIC_DOCKER_IMAGE := tacc/tapis-cli:latest
 
 DOCKER_BUILD_ARGS ?= --force-rm
 DOCKERFILE ?= Dockerfile
 
+DOCKER_MOUNT_AUTHCACHE := -v $(HOME)/.agave:/home/.agave
 DOCKER_MOUNT := -v $(CURDIR):/agave-cli
 DOCKER_FLAGS := docker run --rm -it $(DOCKER_MOUNT)
 
@@ -42,4 +44,7 @@ clean:
 	make -C docs clean
 
 public-image:
-	docker build $(DOCKER_BUILD_ARGS)  -f Dockerfile.public -t tacc/tapis-cli:latest .
+	docker build $(DOCKER_BUILD_ARGS) -f Dockerfile.public -t tacc/tapis-cli:latest .
+
+interactive: public-image
+	docker run --rm -it $(DOCKER_MOUNT) $(DOCKER_MOUNT_AUTHCACHE) $(PUBLIC_DOCKER_IMAGE) bash

--- a/bin/libs/python/easydict/__init__.py
+++ b/bin/libs/python/easydict/__init__.py
@@ -95,10 +95,10 @@ class EasyDict(dict):
             d = {}
         if kwargs:
             d.update(**kwargs)
-        for k, v in d.items():
+        for k, v in list(d.items()):
             setattr(self, k, v)
         # Class attributes
-        for k in self.__class__.__dict__.keys():
+        for k in list(self.__class__.__dict__.keys()):
             if not (k.startswith('__') and k.endswith('__')):
                 setattr(self, k, getattr(self, k))
 

--- a/bin/libs/python/embedcurl.py
+++ b/bin/libs/python/embedcurl.py
@@ -5,7 +5,12 @@
 # embedcurl.io and hurl.it references you can share
 #
 
-import json, sys, argparse, re, urllib, base64
+from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import chr
+from builtins import hex
+import json, sys, argparse, re, urllib.request, urllib.parse, urllib.error, base64
 from operator import attrgetter
 
 debug = False
@@ -60,7 +65,7 @@ def encodeURIComponent(str):
 def unescape(str):
 
     def replace(match):
-        return unichr(int(match.group(1), 16))
+        return chr(int(match.group(1), 16))
 
     return re.sub(r'%u([a-fA-F0-9]{4}|[a-fA-F0-9]{2})', replace, str)
 
@@ -81,24 +86,24 @@ def main():
 
     if args.veryverbose:
 
-        print "Calling " + remotequery + "\n"
+        print("Calling " + remotequery + "\n")
 
-    response = urllib.urlopen(remotequery).read()
+    response = urllib.request.urlopen(remotequery).read()
 
     if args.hurlit or True:
 
-        print 'Showing hurl.it url here'
+        print('Showing hurl.it url here')
         p = re.compile('<span class="hurl"><a href="(.*)" target="_blank">')
         hurls = p.findall(response)
 
         if len(hurls) > 0:
-            print hurls[0]
+            print(hurls[0])
         else:
             raise Exception('No hurl.it url found')
 
     if args.verbose or args.veryverbose:
 
-        print response + "\n"
+        print(response + "\n")
 
 
 if __name__ == "__main__":
@@ -108,4 +113,4 @@ if __name__ == "__main__":
         if debug:
             raise
         else:
-            print e
+            print(e)

--- a/bin/libs/python/pydotjson.py
+++ b/bin/libs/python/pydotjson.py
@@ -4,6 +4,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from builtins import map
+from past.builtins import basestring
 from easydict import EasyDict as edict
 import json, sys, argparse, re
 from operator import attrgetter
@@ -107,7 +109,7 @@ def main():
                     print(
                         'Resulting path query is: map(attrgetter({0}), eval({1}))'.
                         format(tokens[0], tokens[1]))
-                query_result = map(attrgetter(tokens[1]), eval(tokens[0]))
+                query_result = list(map(attrgetter(tokens[1]), eval(tokens[0])))
             else:
                 if debug:
                     print('Resulting path query is: ' + json_path)

--- a/bin/libs/python/pywritejson.py
+++ b/bin/libs/python/pywritejson.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from builtins import str
 import argparse
 import json
 import os

--- a/bin/libs/python/richtext.py
+++ b/bin/libs/python/richtext.py
@@ -4,13 +4,16 @@
 # A Python >=2.7 command line utility for converting json responses into a rich format
 #
 
+from __future__ import print_function
+from builtins import zip
+from builtins import range
 import sys
 debug = False
 
 
 def print_table(table):
 
-    zip_table = zip(*table)
+    zip_table = list(zip(*table))
     widths = [max(len(value) for value in row) for row in zip_table]
 
     for row in table:


### PR DESCRIPTION
This PR adds concurrent support for Python2.7.16 and Python 3.6.x to the CLI. Several Python dependencies in `bin/lib/python` are now modernized and limited interactive testing has been performed. 
                                                                                
## Description
                                                         
1. Updated `pydotjson.py`, `pywritejson.py`, `easydict` and `richtext.py` to support Python2/3
2. Added new Makefile targets `interactive` and `interactive-py2` which load up the CLI in a container that runs in the local working directory while mounting the `$HOME/.agave`  cache directory in the container so that processes use the user's credentials.                    
                                                                                
## Motivation and Context                                                       

This change is submitted because many users are transitioning to Python3 and the retrograde behavior of the CLI was preventing that. Some users are remaining with Python2 for the time being, so 
any changes made must support both languages. 

- [ x ] I have raised an issue to propose this change (#104)                                                                         
                                                                                
